### PR TITLE
fix an error of resolveFile method

### DIFF
--- a/lib/less/aliases-plugin.ts
+++ b/lib/less/aliases-plugin.ts
@@ -75,6 +75,9 @@ export class LessAliasesPlugin {
         }
       }
 
+      if (!isHited) {
+        return filename;
+      }
       if (isHited && !resolvedPath) {
         throw new Error(`Invalid @import: ${filename}`);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qiniu/typed-less-modules",
-  "version": "0.1.2",
+  "version": "0.1.2-1",
   "description": "TypeScript type definition generator for LESS CSS Modules",
   "main": "index.js",
   "license": "Apache",


### PR DESCRIPTION
The `resolveFile` method is not completely implemented. It should return the raw filename if it's not aliased at all.

[Background]
The `AliasePlugin` is not properly implemented. When compilling less file, less calls `loadFileSync` at first (1), then it calls`super.loadFileSync`(2). The super method directly calls `this.resolveFile` which falls back to AliasePlugin again(3), then again calls `super.loadFile`. Both step 1 and step 2 calls `resolveFile` method, twice. So the `resolveFile` should be safe enough to be called multiple times.