### PR TITLE
fix(aliases-plugin): resolve 根路径直接返回

### DIFF
--- a/lib/less/aliases-plugin.ts
+++ b/lib/less/aliases-plugin.ts
@@ -26,6 +26,10 @@ export class LessAliasesPlugin {
     const { aliases = {} } = this;
 
     function resolve(filename: string) {
+      // 根路径直接返回
+      if(filename[0] === '/') {
+          return filename;
+      }
       // 从长到短排序可以有效避免 `a` 和 `ab` 别名冲突的问题
       const aliasNames = Object.keys(aliases).sort(
         (a, b) => b.length - a.length


### PR DESCRIPTION
根路径会导致以下报错, 然后外层 Promise 永远 pending

```
'Error: [typed-less-modules:aliases-plugin]: '/root/projects/reco-tile/node_modules/antd/lib/style/themes/default.less' not found.
    at resolveFile (/root/projects/reco-tile/node_modules/@qiniu/typed-less-modules/dist/lib/less/aliases-plugin.js:92:23)
    at AliasePlugin.loadFile (/root/projects/reco-tile/node_modules/@qiniu/typed-less-modules/dist/lib/less/aliases-plugin.js:116:61)
    at AliasePlugin.FileManager.loadFileSync (/root/projects/reco-tile/node_modules/less/lib/less-node/file-mana…/reco-tile/node_modules/less/lib/less/visitors/import-visitor.js:103:28)
    at ImportVisitor.visitImport (/root/projects/reco-tile/node_modules/less/lib/less/visitors/import-visitor.js:68:22)
    at Visitor.visit (/root/projects/reco-tile/node_modules/less/lib/less/visitors/visitor.js:70:32)
    at Visitor.visitArray (/root/projects/reco-tile/node_modules/less/lib/less/visitors/visitor.js:101:22)
    at Ruleset.accept (/root/projects/reco-tile/node_modules/less/lib/less/tree/ruleset.js:62:30)'
```